### PR TITLE
Update `org.projectlombok:lombok` to fix test runner.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,8 +89,8 @@ signing {
 dependencies {
 
     // === Code Generation ===
-    compileOnly 'org.projectlombok:lombok:1.18.16'
-    annotationProcessor 'org.projectlombok:lombok:1.18.16'
+    compileOnly 'org.projectlombok:lombok:1.18.20'
+    annotationProcessor 'org.projectlombok:lombok:1.18.20'
 
     // === DTO ===
     implementation('org.modelmapper:modelmapper:1.1.0')


### PR DESCRIPTION
PR fixes issue, related to running tests in Android Studio. For example:
```
2021-06-16T11:28:52.586+0300 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter] > java.lang.IllegalAccessError: class lombok.javac.apt.LombokProcessor (in unnamed module @0x4b338673) cannot access class com.sun.tools.javac.processing.JavacProcessingEnvironment (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.processing to unnamed module @0x4b338673
```