### PR TITLE
Serialize Order's ratio as String to avoid precision loss

### DIFF
--- a/src/main/java/io/zksync/domain/swap/Order.java
+++ b/src/main/java/io/zksync/domain/swap/Order.java
@@ -55,25 +55,25 @@ public class Order {
     }
 
     @JsonGetter("ratio")
-    public List<BigInteger> getRatioJson() {
-        return Arrays.asList(ratio.component1(), ratio.component2());
+    public List<String> getRatioJson() {
+        return Arrays.asList(ratio.component1().toString(), ratio.component2().toString());
     }
 
     @JsonSetter("ratio")
-    public void setRatio(List<BigInteger> ratio) {
+    public void setRatio(List<String> ratio) {
         if (ratio == null || ratio.size() != 2) {
             throw new IllegalArgumentException("Incorrect amount of ratio");
         }
-        this.ratio = new Tuple2<>(ratio.get(0), ratio.get(1));
+        this.ratio = new Tuple2<>(new BigInteger(ratio.get(0)), new BigInteger(ratio.get(1)));
     }
 
     @JsonGetter("amount")
-    public String getAmountSrting() {
+    public String getAmountString() {
         return amount.toString();
     }
 
     @JsonSetter("amount")
-    public void getAmountSrting(String amount) {
+    public void setAmountString(String amount) {
         this.amount = new BigInteger(amount);
     }
 

--- a/src/main/java/io/zksync/domain/transaction/Transfer.java
+++ b/src/main/java/io/zksync/domain/transaction/Transfer.java
@@ -47,12 +47,12 @@ public class Transfer implements ZkSyncTransaction {
     private TimeRange timeRange;
 
     @JsonGetter("amount")
-    public String getAmountSrting() {
+    public String getAmountString() {
         return amount.toString();
     }
 
     @JsonSetter("amount")
-    public void getAmountSrting(String amount) {
+    public void setAmountString(String amount) {
         this.amount = new BigInteger(amount);
     }
 

--- a/src/main/java/io/zksync/domain/transaction/Withdraw.java
+++ b/src/main/java/io/zksync/domain/transaction/Withdraw.java
@@ -43,12 +43,12 @@ public class Withdraw implements ZkSyncTransaction {
     private TimeRange timeRange;
 
     @JsonGetter("amount")
-    public String getAmountSrting() {
+    public String getAmountString() {
         return amount.toString();
     }
 
     @JsonSetter("amount")
-    public void getAmountSrting(String amount) {
+    public void setAmountString(String amount) {
         this.amount = new BigInteger(amount);
     }
 


### PR DESCRIPTION
- fixed `ratio` to be serialized as String
- fixed few typos from previous PR (getAmountString)