### PR TITLE
Changed public urls of ZkSync testnet servers

### DIFF
--- a/src/main/java/io/zksync/domain/ChainId.java
+++ b/src/main/java/io/zksync/domain/ChainId.java
@@ -10,12 +10,17 @@ public enum ChainId {
     Rinkeby(4),
     /// Ethereum Ropsten testnet.
     Ropsten(3),
+    /// Optimism Goerli Testnet
+    Goerli(420),
+    /// Ethereum Sepolia Testnet
+    Sepolia(11155111),
+
     /// Self-hosted Ethereum & zkSync networks.
     Localhost(9);
 
-    private long id;
+    private final long id;
 
-    private ChainId(long id) {
+    ChainId(long id) {
         this.id = id;
     }
 }

--- a/src/main/java/io/zksync/provider/AsyncProvider.java
+++ b/src/main/java/io/zksync/provider/AsyncProvider.java
@@ -167,21 +167,22 @@ public interface AsyncProvider {
      * @return ZkSync provider object
      */
     static AsyncProvider defaultProvider(ChainId chainId) {
-        HttpTransport transport = null;
+        HttpTransport transport;
         switch (chainId) {
             case Mainnet: transport = new HttpTransport("https://api.zksync.io/jsrpc"); break;
-            case Rinkeby: transport = new HttpTransport("https://rinkeby-api.zksync.io/jsrpc"); break;
-            case Ropsten: transport = new HttpTransport("https://ropsten-api.zksync.io/jsrpc"); break;
+            case Sepolia: transport = new HttpTransport("https://sepolia-api.zksync.io/jsrpc"); break;
+            case Goerli: transport = new HttpTransport("https://goerli-api.zksync.io/jsrpc"); break;
             case Localhost: transport = new HttpTransport("http://127.0.0.1:3030"); break;
+            default: throw new IllegalArgumentException("Unsupported beta network for given chain id");
         }
         return new DefaultAsyncProvider(transport);
     }
 
     static AsyncProvider betaProvider(ChainId chainId) {
-        HttpTransport transport = null;
+        HttpTransport transport;
         switch (chainId) {
-            case Rinkeby: transport = new HttpTransport("https://rinkeby-beta-api.zksync.io/jsrpc"); break;
-            case Ropsten: transport = new HttpTransport("https://ropsten-beta-api.zksync.io/jsrpc"); break;
+            case Sepolia: transport = new HttpTransport("https://sepolia-api.zksync.io/jsrpc"); break;
+            case Goerli: transport = new HttpTransport("https://goerli-api.zksync.io/jsrpc"); break;
             default: throw new IllegalArgumentException("Unsupported beta network for given chain id");
         }
         return new DefaultAsyncProvider(transport);

--- a/src/main/java/io/zksync/provider/Provider.java
+++ b/src/main/java/io/zksync/provider/Provider.java
@@ -166,21 +166,22 @@ public interface Provider {
      * @return ZkSync provider object
      */
     static Provider defaultProvider(ChainId chainId) {
-        HttpTransport transport = null;
+        HttpTransport transport;
         switch (chainId) {
             case Mainnet: transport = new HttpTransport("https://api.zksync.io/jsrpc"); break;
-            case Rinkeby: transport = new HttpTransport("https://rinkeby-api.zksync.io/jsrpc"); break;
-            case Ropsten: transport = new HttpTransport("https://ropsten-api.zksync.io/jsrpc"); break;
+            case Sepolia: transport = new HttpTransport("https://sepolia-api.zksync.io/jsrpc"); break;
+            case Goerli: transport = new HttpTransport("https://goerli-api.zksync.io/jsrpc"); break;
             case Localhost: transport = new HttpTransport("http://127.0.0.1:3030"); break;
+            default: throw new IllegalArgumentException("Unsupported network for given chain id");
         }
         return new DefaultProvider(transport);
     }
 
     static Provider betaProvider(ChainId chainId) {
-        HttpTransport transport = null;
+        HttpTransport transport;
         switch (chainId) {
-            case Rinkeby: transport = new HttpTransport("https://rinkeby-beta-api.zksync.io/jsrpc"); break;
-            case Ropsten: transport = new HttpTransport("https://ropsten-beta-api.zksync.io/jsrpc"); break;
+            case Sepolia: transport = new HttpTransport("https://sepolia-beta-api.zksync.io/jsrpc"); break;
+            case Goerli: transport = new HttpTransport("https://goerli-beta-api.zksync.io/jsrpc"); break;
             default: throw new IllegalArgumentException("Unsupported beta network for given chain id");
         }
         return new DefaultProvider(transport);


### PR DESCRIPTION
 Changed public urls of ZkSync testnet servers to Goerli and Sepolia instead of Ropsten and Rinkeby